### PR TITLE
ci: simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,6 @@ on:
     branches: [main]
     paths: ['sources/**', 'metanorma.yml', 'metanorma.release.yml']
   workflow_dispatch:
-    inputs:
-      include-pattern:
-        description: 'Glob pattern to filter documents for release'
-        required: false
-        default: '*'
-      force:
-        description: 'Force release even if content is unchanged'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -24,6 +14,5 @@ jobs:
     uses: actions-mn/.github/.github/workflows/metanorma-release.yml@main
     with:
       default-visibility: private
-      include-pattern: ${{ github.event.inputs.include-pattern || '*' }}
-      force: ${{ github.event.inputs.force || 'false' }}
     secrets: inherit
+


### PR DESCRIPTION
Remove workflow_dispatch inputs (include-pattern, force) to fix reusable workflow resolution issue.